### PR TITLE
Synopsys Maker: Handle filename commas

### DIFF
--- a/Mod Files/emustation/scripts/synopsis_maker/default.py
+++ b/Mod Files/emustation/scripts/synopsis_maker/default.py
@@ -32,6 +32,7 @@ if not Select_Emu_Folder == -1:
 				text_filename = text_filename.replace('&#39;',"'")
 				text_filename = text_filename.replace('&amp;','&')
 				text_filename = text_filename.replace('+','_')
+				text_filename = text_filename.replace(',','_')
 				text_filename_ext = "Filename: " + text_filename
 				text_filename = text_filename[:-4] # remove extension
 				text_filename = text_filename[:38] # truncate to fit 42 character limit - extension


### PR DESCRIPTION
Hit a snag when I happened to try to get through a file name which included the list of the game's languages.